### PR TITLE
fix: Align precedence of maps with other plugins

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-syntax */
 
 import { rollupImportMapPlugin as importMapPlugin } from 'rollup-plugin-import-map';
-import fetch from 'node-fetch';
 import { helpers } from '@eik/common';
+import fetch from 'node-fetch';
 
 async function fetchImportMaps(urls = []) {
     try {
@@ -37,15 +37,13 @@ export default function esmImportToUrl({
         name: 'eik-rollup-plugin',
 
         async buildStart(options) {
+            // Load eik config from eik.json or package.json
             const config = await helpers.getDefaults(path);
-            for (const map of config.map) {
-                pUrls.push(map);
-            }
 
-            const fetched = await fetchImportMaps(pUrls);
-            const mappings = pMaps.concat(fetched);
+            // Fetch import maps from the server
+            const fetched = await fetchImportMaps([...config.map, ...pUrls]);
 
-            plugin = importMapPlugin(mappings);
+            plugin = importMapPlugin([...fetched, ...pMaps]);
             await plugin.buildStart(options);
         },
 

--- a/tap-snapshots/test-plugin.js-TAP.test.js
+++ b/tap-snapshots/test-plugin.js-TAP.test.js
@@ -5,10 +5,67 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/plugin.js TAP plugin() - Import map defined through constructor "maps" argument take precedence over import map defined in eik.json > Should rewrite import statement to https://cdn.eik.dev/lit-element/v2 1`] = `
+import { html } from 'lit-html/lit-html';
+import { css } from 'lit-html';
+import { LitElement } from 'https://cdn.eik.dev/lit-element/v2';
+
+class Inner extends LitElement {
+    static get styles() {
+        return [css\`:host { color: red; }\`];
+    }
+
+    render(world) {
+        return html\`<p>Hello \${world}!</p>\`;
+    }
+}
+
+export default Inner;
+
+`
+
+exports[`test/plugin.js TAP plugin() - Import map defined through constructor "maps" argument take precedence over import map defined through constructor "urls" argument > Should rewrite import statement to https://cdn.eik.dev/lit-element/v2 1`] = `
+import { html } from 'lit-html/lit-html';
+import { css } from 'lit-html';
+import { LitElement } from 'https://cdn.eik.dev/lit-element/v2';
+
+class Inner extends LitElement {
+    static get styles() {
+        return [css\`:host { color: red; }\`];
+    }
+
+    render(world) {
+        return html\`<p>Hello \${world}!</p>\`;
+    }
+}
+
+export default Inner;
+
+`
+
+exports[`test/plugin.js TAP plugin() - Import map defined through constructor "urls" argument take precedence over import map defined in eik.json > Should rewrite import statement to https://cdn.eik.dev/lit-element/v2 1`] = `
+import { html } from 'lit-html/lit-html';
+import { css } from 'lit-html';
+import { LitElement } from 'https://cdn.eik.dev/lit-element/v2';
+
+class Inner extends LitElement {
+    static get styles() {
+        return [css\`:host { color: red; }\`];
+    }
+
+    render(world) {
+        return html\`<p>Hello \${world}!</p>\`;
+    }
+}
+
+export default Inner;
+
+`
+
 exports[`test/plugin.js TAP plugin() - import map fetched from a URL > import maps from urls 1`] = `
-import { html } from 'https://cdn.pika.dev/lit-html/v2';
-import { css } from 'https://cdn.pika.dev/lit-html/v1';
-import { LitElement } from 'https://cdn.pika.dev/lit-element/v2';
+import { html } from 'https://cdn.eik.dev/lit-html/v2';
+import { css } from 'https://cdn.eik.dev/lit-html/v1';
+import { LitElement } from 'https://cdn.eik.dev/lit-element/v2';
 
 class Inner extends LitElement {
     static get styles() {
@@ -25,28 +82,9 @@ export default Inner;
 `
 
 exports[`test/plugin.js TAP plugin() - import map fetched from a URL via eik.json > eik.json import-map string 1`] = `
-import { html } from 'https://cdn.pika.dev/lit-html/v2';
-import { css } from 'https://cdn.pika.dev/lit-html/v1';
-import { LitElement } from 'https://cdn.pika.dev/lit-element/v2';
-
-class Inner extends LitElement {
-    static get styles() {
-        return [css\`:host { color: red; }\`];
-    }
-
-    render(world) {
-        return html\`<p>Hello \${world}!</p>\`;
-    }
-}
-
-export default Inner;
-
-`
-
-exports[`test/plugin.js TAP plugin() - import maps via eik.json, URLs and direct definitions > import maps from eik.json, urls and direct definition 1`] = `
-import { html } from 'https://cdn.pika.dev/lit-html/v2';
-import { css } from 'https://cdn.pika.dev/lit-html/v1';
-import { LitElement } from 'https://cdn.pika.dev/lit-element/v2';
+import { html } from 'https://cdn.eik.dev/lit-html/v2';
+import { css } from 'https://cdn.eik.dev/lit-html/v1';
+import { LitElement } from 'https://cdn.eik.dev/lit-element/v2';
 
 class Inner extends LitElement {
     static get styles() {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,8 +1,9 @@
-import fs from 'fs';
 import { rollup } from 'rollup';
+import fastify from 'fastify';
 import path from 'path';
 import tap from 'tap';
-import fastify from 'fastify';
+import fs from 'fs';
+
 import plugin from '../src/plugin.js';
 import { __dirname } from '../utils/dirname.js';
 
@@ -19,14 +20,14 @@ tap.test('plugin() - import map fetched from a URL', async (t) => {
     server.get('/one', (request, reply) => {
         reply.send({
             imports: {
-                'lit-element': 'https://cdn.pika.dev/lit-element/v2',
+                'lit-element': 'https://cdn.eik.dev/lit-element/v2',
             },
         });
     });
     server.get('/two', (request, reply) => {
         reply.send({
             imports: {
-                'lit-html': 'https://cdn.pika.dev/lit-html/v1',
+                'lit-html': 'https://cdn.eik.dev/lit-html/v1',
             },
         });
     });
@@ -40,7 +41,7 @@ tap.test('plugin() - import map fetched from a URL', async (t) => {
         plugins: [plugin({
             maps: [{
                 imports: {
-                    'lit-html/lit-html': 'https://cdn.pika.dev/lit-html/v2',
+                    'lit-html/lit-html': 'https://cdn.eik.dev/lit-html/v2',
                 },
             }],
             urls: [`${address}/one`, `${address}/two`],
@@ -60,9 +61,9 @@ tap.test('plugin() - import map fetched from a URL via eik.json', async (t) => {
     server.get('/one', (request, reply) => {
         reply.send({
             imports: {
-                'lit-element': 'https://cdn.pika.dev/lit-element/v2',
-                'lit-html': 'https://cdn.pika.dev/lit-html/v1',
-                'lit-html/lit-html': 'https://cdn.pika.dev/lit-html/v2',
+                'lit-element': 'https://cdn.eik.dev/lit-element/v2',
+                'lit-html': 'https://cdn.eik.dev/lit-html/v1',
+                'lit-html/lit-html': 'https://cdn.eik.dev/lit-html/v2',
             },
         });
     });
@@ -96,22 +97,16 @@ tap.test('plugin() - import map fetched from a URL via eik.json', async (t) => {
     t.end();
 });
 
-tap.test('plugin() - import maps via eik.json, URLs and direct definitions', async (t) => {
+tap.test('plugin() - Import map defined through constructor "maps" argument take precedence over import map defined in eik.json', async (t) => {
     const server = fastify();
     server.get('/one', (request, reply) => {
         reply.send({
             imports: {
-                'lit-element': 'https://cdn.pika.dev/lit-element/v2',
+                'lit-element': 'https://cdn.eik.dev/lit-element/v1',
             },
         });
     });
-    server.get('/two', (request, reply) => {
-        reply.send({
-            imports: {
-                'lit-html': 'https://cdn.pika.dev/lit-html/v1',
-            },
-        });
-    });
+
     const address = await server.listen();
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
@@ -119,8 +114,8 @@ tap.test('plugin() - import maps via eik.json, URLs and direct definitions', asy
         server: address,
         version: '1.0.0',
         files: {
-            '/css': '/src/css/**/*',
-            '/js': '/src/js/**/*',
+            '/css': '/src/css/',
+            '/js': '/src/js/',
         },
         'import-map': `${address}/one`,
     }));
@@ -133,18 +128,128 @@ tap.test('plugin() - import maps via eik.json, URLs and direct definitions', asy
         plugins: [plugin({
             maps: [{
                 imports: {
-                    'lit-html/lit-html': 'https://cdn.pika.dev/lit-html/v2',
+                    'lit-element': 'https://cdn.eik.dev/lit-element/v2',
                 },
             }],
-            urls: [`${address}/two`],
         })],
     };
 
     const bundle = await rollup(options);
     const { output } = await bundle.generate({ format: 'esm' });
 
-    t.matchSnapshot(clean(output[0].code), 'import maps from eik.json, urls and direct definition');
+    t.matchSnapshot(clean(output[0].code), 'Should rewrite import statement to https://cdn.eik.dev/lit-element/v2');
     await server.close();
     await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
     t.end();
 });
+
+tap.test('plugin() - Import map defined through constructor "urls" argument take precedence over import map defined in eik.json', async (t) => {
+    const server = fastify();
+    server.get('/one', (request, reply) => {
+        reply.send({
+            imports: {
+                'lit-element': 'https://cdn.eik.dev/lit-element/v1',
+            },
+        });
+    });
+    
+    server.get('/two', (request, reply) => {
+        reply.send({
+            imports: {
+                'lit-element': 'https://cdn.eik.dev/lit-element/v2',
+            },
+        });
+    });
+    
+    const address = await server.listen();
+
+    await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
+        name: 'test',
+        server: address,
+        version: '1.0.0',
+        files: {
+            '/css': '/src/css/',
+            '/js': '/src/js/',
+        },
+        'import-map': `${address}/one`,
+    }));
+
+    const options = {
+        input: file,
+        onwarn: () => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            urls: [
+                `${address}/two`
+            ],
+        })],
+    };
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'Should rewrite import statement to https://cdn.eik.dev/lit-element/v2');
+    await server.close();
+    await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
+    t.end();
+});
+
+tap.test('plugin() - Import map defined through constructor "maps" argument take precedence over import map defined through constructor "urls" argument', async (t) => {
+    const server = fastify();
+    server.get('/one', (request, reply) => {
+        reply.send({
+            imports: {
+                'lit-element': 'https://cdn.eik.dev/lit-element/v0',
+            },
+        });
+    });
+    
+    server.get('/two', (request, reply) => {
+        reply.send({
+            imports: {
+                'lit-element': 'https://cdn.eik.dev/lit-element/v1',
+            },
+        });
+    });
+    
+    const address = await server.listen();
+
+    await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
+        name: 'test',
+        server: address,
+        version: '1.0.0',
+        files: {
+            '/css': '/src/css/',
+            '/js': '/src/js/',
+        },
+        'import-map': `${address}/one`,
+    }));
+
+    const options = {
+        input: file,
+        onwarn: () => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            maps: [{
+                imports: {
+                    'lit-element': 'https://cdn.eik.dev/lit-element/v2',
+                },
+            }],
+            urls: [
+                `${address}/two`
+            ],
+        })],
+    };
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'Should rewrite import statement to https://cdn.eik.dev/lit-element/v2');
+    await server.close();
+    await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
+    t.end();
+});
+
+

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -152,7 +152,7 @@ tap.test('plugin() - Import map defined through constructor "urls" argument take
             },
         });
     });
-    
+
     server.get('/two', (request, reply) => {
         reply.send({
             imports: {
@@ -160,7 +160,7 @@ tap.test('plugin() - Import map defined through constructor "urls" argument take
             },
         });
     });
-    
+
     const address = await server.listen();
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
@@ -181,7 +181,7 @@ tap.test('plugin() - Import map defined through constructor "urls" argument take
         },
         plugins: [plugin({
             urls: [
-                `${address}/two`
+                `${address}/two`,
             ],
         })],
     };
@@ -204,7 +204,7 @@ tap.test('plugin() - Import map defined through constructor "maps" argument take
             },
         });
     });
-    
+
     server.get('/two', (request, reply) => {
         reply.send({
             imports: {
@@ -212,7 +212,7 @@ tap.test('plugin() - Import map defined through constructor "maps" argument take
             },
         });
     });
-    
+
     const address = await server.listen();
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
@@ -238,7 +238,7 @@ tap.test('plugin() - Import map defined through constructor "maps" argument take
                 },
             }],
             urls: [
-                `${address}/two`
+                `${address}/two`,
             ],
         })],
     };
@@ -251,5 +251,3 @@ tap.test('plugin() - Import map defined through constructor "maps" argument take
     await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
     t.end();
 });
-
-


### PR DESCRIPTION
This aligns the precedence of how import maps can be provided to the plugin with the rules for precedence in the other plugins.