### PR TITLE
fix: Fix node-fetch 3.x regression in CJS build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: npm install
         run: |
           npm install
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: npm install
         run: |
           npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "prepare": "npm run -s build",
-    "test": "tap --no-esm test/*.js --no-coverage",
-    "test:snapshot": "TAP_SNAPSHOT=1 tap --no-esm test/*.js --no-coverage",
+    "test": "tap --no-coverage",
+    "test:snapshot": "TAP_SNAPSHOT=1 tap --no-coverage",
     "lint": "eslint . --ext=js",
     "lint:fix": "eslint . --fix --ext=js",
     "start": "node --experimental-modules ./example/server.mjs",
@@ -46,22 +46,18 @@
   "homepage": "https://github.com/eik-lib/rollup-plugin#readme",
   "devDependencies": {
     "@semantic-release/changelog": "6.0.1",
-    "@semantic-release/commit-analyzer": "9.0.2",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "8.0.2",
-    "@semantic-release/npm": "8.0.3",
-    "@semantic-release/release-notes-generator": "10.0.3",
-    "eslint": "7.32.0",
-    "eslint-config-airbnb-base": "14.2.1",
-    "eslint-plugin-import": "2.24.0",
-    "fastify": "3.14.1",
-    "rollup": "2.39.0",
+    "eslint": "8.6.0",
+    "eslint-config-airbnb-base": "15.0.0",
+    "eslint-plugin-import": "2.25.4",
+    "fastify": "3.25.3",
+    "rollup": "2.63.0",
     "semantic-release": "18.0.1",
-    "tap": "14.11.0"
+    "tap": "15.1.6"
   },
   "dependencies": {
     "@eik/common": "3.0.0",
-    "node-fetch": "3.1.0",
+    "undici": "4.12.1",
     "rollup-plugin-import-map": "2.2.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ export default {
     input: 'src/plugin.js',
     external: [
         'rollup-plugin-import-map',
-        'node-fetch',
+        'undici',
         'path',
         'url',
         'fs',

--- a/tap-snapshots/package.json
+++ b/tap-snapshots/package.json
@@ -1,1 +1,0 @@
-{"type": "commonjs"}

--- a/tap-snapshots/test/plugin.js.test.cjs
+++ b/tap-snapshots/test/plugin.js.test.cjs
@@ -20,7 +20,7 @@ class Inner extends LitElement {
     }
 }
 
-export default Inner;
+export { Inner as default };
 
 `
 
@@ -39,7 +39,7 @@ class Inner extends LitElement {
     }
 }
 
-export default Inner;
+export { Inner as default };
 
 `
 
@@ -58,7 +58,7 @@ class Inner extends LitElement {
     }
 }
 
-export default Inner;
+export { Inner as default };
 
 `
 
@@ -77,7 +77,7 @@ class Inner extends LitElement {
     }
 }
 
-export default Inner;
+export { Inner as default };
 
 `
 
@@ -96,6 +96,6 @@ class Inner extends LitElement {
     }
 }
 
-export default Inner;
+export { Inner as default };
 
 `

--- a/utils/dirname.js
+++ b/utils/dirname.js
@@ -1,4 +1,0 @@
-import path from 'path';
-import url from 'url';
-
-export const __dirname = path.dirname(url.fileURLToPath(import.meta.url));


### PR DESCRIPTION
Merging #57 broke the CJS build of this module due to `node-fetch` version 3 supporting ESM only. Issue is fixed by replacing `node-fetch` with [`undici`](https://undici.nodejs.org/).

Also updated all dependencies and removed some unnecessary semantic release dependencies. 

Fixes: #69