### PR TITLE
fix: fixing redirect issue with node v24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [18, 20]
+        node-version: [18, 20, 22, 24]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ import { LitElement, html, css } from "https://cdn.eik.dev/lit-element/v2";
 
 This plugin takes an [import map](https://github.com/WICG/import-maps) as options:
 
-| option | default        | type     | required | details                                 |
-| ------ | -------------- | -------- | -------- | --------------------------------------- |
-| path   | `cwd/eik.json` | `string` | `false`  | Path to eik.json file.                  |
-| urls   | `[]`           | `array`  | `false`  | Array of import map URLs to fetch from. |
-| maps   | `[]`           | `array`  | `false`  | Array of import map as objects.         |
+| option            | default        | type       | required   | details                                                  |
+|-------------------|----------------|------------|------------|----------------------------------------------------------|
+| path              | `cwd/eik.json` | `string`   | `false`    | Path to eik.json file.                                   |
+| urls              | `[]`           | `array`    | `false`    | Array of import map URLs to fetch from.                  |
+| maps              | `[]`           | `array`    | `false`    | Array of import map as objects.                          |
+| maxRedirections   | `2`            | `number`   | `false`    | Maximum number of redirects when retrieving import maps. |
 
 ## Note on the rollup external option
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   "dependencies": {
     "@eik/common": "3.0.1",
     "rollup-plugin-import-map": "3.0.0",
-    "undici": "5.29.0"
+    "undici": "7.8.0"
   }
 }

--- a/tap-snapshots/test/plugin.js.test.cjs
+++ b/tap-snapshots/test/plugin.js.test.cjs
@@ -129,3 +129,28 @@ class Inner extends LitElement {
 export { Inner as default };
 
 `
+
+exports[`test/plugin.js > TAP > plugin() - import map fetched from a URL with a redirect > import maps from urls with redirects 1`] = `
+import { html } from 'lit-html/lit-html';
+import { css } from 'https://cdn.eik.dev/lit-element/2.2.2/file.js';
+import { LitElement } from 'lit-element';
+
+class Inner extends LitElement {
+  static get styles() {
+    return [
+      css\`
+        :host {
+          color: red;
+        }
+      \`,
+    ];
+  }
+
+  render(world) {
+    return html\`<p>Hello \${world}!</p>\`;
+  }
+}
+
+export { Inner as default };
+
+`


### PR DESCRIPTION
In Node.js v24 Undici was updated to version 7, which included dropping support for the default 'maxRedirections' option in undici.request, leading redirects to return empty responses.

This fix uses an interceptor to enable redirects.