### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:eik-lib/rollup-plugin.git"
+    "url": "git+https://github.com/eik-lib/rollup-plugin.git"
   },
   "keywords": [
     "rollup-plugin",


### PR DESCRIPTION
## Summary
- replace the package repository metadata SSH URL with a public `git+https` URL
- keep the metadata pointing at the same GitHub repository

## Validation
- node package metadata assertion
- git diff --check
- git ls-remote https://github.com/eik-lib/rollup-plugin.git HEAD
- npm ci --ignore-scripts
- npm run lint
- npm run types
- npm test
- npm run build
- npm pack --dry-run

Note: the Rollup build emits its existing external-dependency warning for `@eik/common`, but exits successfully.