### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:eik-lib/rollup-plugin.git"
+    "url": "git+https://github.com/eik-lib/rollup-plugin.git"
   },
   "keywords": [
     "rollup-plugin",


### PR DESCRIPTION
## Summary

- Update the npm package repository metadata to use the public HTTPS GitHub URL.
- Keep the repository target unchanged while avoiding an SSH-only URL that requires GitHub key access.

## Validation

- `node` metadata assertion for `package.json`
- `git diff --check`
- `git ls-remote https://github.com/eik-lib/rollup-plugin.git HEAD`
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run types`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
